### PR TITLE
Release Cordova SDK version 4.0.2

### DIFF
--- a/userexperior-cordova-plugin/package.json
+++ b/userexperior-cordova-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userexperior-cordova-plugin",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "spec": "latest",
   "description": "userexperior cordova plugin",
   "cordova": {

--- a/userexperior-cordova-plugin/plugin.xml
+++ b/userexperior-cordova-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="userexperior-cordova-plugin" version="4.0.1" spec="4.0.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="userexperior-cordova-plugin" version="4.0.2" spec="4.0.2">
    <name>UserExperiorPlugin</name>
    <js-module name="UserExperiorPlugin" src="www/UserExperiorPlugin.js">
       <clobbers target="UserExperior" />

--- a/userexperior-cordova-plugin/src/android/userexperior-plugin.gradle
+++ b/userexperior-cordova-plugin/src/android/userexperior-plugin.gradle
@@ -16,7 +16,7 @@ repositories{
 dependencies {
     //compile(name:'userexperiorsdk-V2-2-04202018', ext:'aar')
 	//compile 'com.userexperior:userexperior-android:+'
-	implementation 'com.userexperior:userexperior-android:7.3.6'
+	implementation 'com.userexperior:userexperior-android:7.3.7'
     //implementation 'com.userexperior:userexperior-android:1.8.0-SNAPSHOT'
 }
 

--- a/userexperior-cordova-plugin/www/UserExperiorPlugin.js
+++ b/userexperior-cordova-plugin/www/UserExperiorPlugin.js
@@ -1,7 +1,7 @@
 var exec = require('cordova/exec');
 
 const fw = "ca"; // framework: cordova
-const sv = "4.0.1"; // SDK/Plugin Version
+const sv = "4.0.2"; // SDK/Plugin Version
 
 var UserExperiorPlugin = function() {};
 


### PR DESCRIPTION
# Description

- There is a change in the Android platform only, which is recycling bitmap below Android 14, i.e. API level 34 only, as it's taken care of in the later versions, so updated UE Android SDK version to 7.3.7

# Links

[ISS-124870](https://app.devrev.ai/devrev/works/ISS-124870)