### PR TITLE
Release Cordova SDK version 4.0.3

### DIFF
--- a/userexperior-cordova-plugin/package.json
+++ b/userexperior-cordova-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userexperior-cordova-plugin",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "spec": "latest",
   "description": "userexperior cordova plugin",
   "cordova": {

--- a/userexperior-cordova-plugin/plugin.xml
+++ b/userexperior-cordova-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="userexperior-cordova-plugin" version="4.0.2" spec="4.0.2">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="userexperior-cordova-plugin" version="4.0.3" spec="4.0.3">
    <name>UserExperiorPlugin</name>
    <js-module name="UserExperiorPlugin" src="www/UserExperiorPlugin.js">
       <clobbers target="UserExperior" />

--- a/userexperior-cordova-plugin/src/android/userexperior-plugin.gradle
+++ b/userexperior-cordova-plugin/src/android/userexperior-plugin.gradle
@@ -16,7 +16,7 @@ repositories{
 dependencies {
     //compile(name:'userexperiorsdk-V2-2-04202018', ext:'aar')
 	//compile 'com.userexperior:userexperior-android:+'
-	implementation 'com.userexperior:userexperior-android:7.3.7'
+	implementation 'com.userexperior:userexperior-android:7.3.8'
     //implementation 'com.userexperior:userexperior-android:1.8.0-SNAPSHOT'
 }
 

--- a/userexperior-cordova-plugin/www/UserExperiorPlugin.js
+++ b/userexperior-cordova-plugin/www/UserExperiorPlugin.js
@@ -1,7 +1,7 @@
 var exec = require('cordova/exec');
 
 const fw = "ca"; // framework: cordova
-const sv = "4.0.2"; // SDK/Plugin Version
+const sv = "4.0.3"; // SDK/Plugin Version
 
 var UserExperiorPlugin = function() {};
 


### PR DESCRIPTION
# Description

### What's new in this release?

- Debouncer Implementation to fix Mirae Asset ANRs
- Fixed setUserProperties(...) to append all the properties if it is called multiple times, raised by IndusInd
- The getActiveNetworkInfo() call was deprecated so it was replaced with the latest method, also removed usage of TelephonyManager as it required explicit READ_PHONE_STATE permission to avoid any crashes - Clients: ABCD, Bajaj Finserv, now for Network Type, we won't be detecting 2G/3G/4G/5G due to Google Restrictions and dangerous permissions required, we will only show either Cellular or WiFi
- Nuvama was facing crashes on Android 13 due to bad bitmap handling. Handled the recycling of bitmap based on Android version

# Link(s)

- [ISS-129252](https://app.devrev.ai/devrev/works/ISS-129252)